### PR TITLE
resolve improper function call

### DIFF
--- a/test/spec/adapters/miniYak.spec.js
+++ b/test/spec/adapters/miniYak.spec.js
@@ -71,7 +71,7 @@ describe("YakAdapter - MiniYak", function() {
         it('mYak/Yak should be 1M - moon', async () => {
             // Get trader some YAK
             const mintYAKAmount = parseUnits('10', await YAK.decimals())
-            await setERC20Bal(YAK.address, mintYAKAmount, trader.address, 4)
+            await setERC20Bal(YAK.address, trader.address, mintYAKAmount);
             expect(await YAK.balanceOf(trader.address)).to.equal(mintYAKAmount)
             // Swap
             const tknIn = YAK
@@ -94,7 +94,7 @@ describe("YakAdapter - MiniYak", function() {
         it('YAK/mYAK should be 1μ - unmoon', async () => {
             // Get trader some mYak
             const mintMiniYAKAmount = parseUnits('1', await mYAK.decimals())
-            await setERC20Bal(mYAK.address, mintMiniYAKAmount, trader.address, 0)
+            await setERC20Bal(mYAK.address, trader.address, mintMiniYAKAmount)
             expect(await mYAK.balanceOf(trader.address)).to.equal(mintMiniYAKAmount)
             // Swap
             const tknIn = mYAK

--- a/test/spec/adapters/miniYak.spec.js
+++ b/test/spec/adapters/miniYak.spec.js
@@ -115,4 +115,3 @@ describe("YakAdapter - MiniYak", function() {
 
     })
 })
-        


### PR DESCRIPTION
these `setERC20Bal` are not this signature. since the `trader.address` is passed as `_amount` and is not a BigNumber these tests fail.

guessing this is what was meant.